### PR TITLE
Add cross domain config files

### DIFF
--- a/docker/georoot/public/clientaccesspolicy.xml
+++ b/docker/georoot/public/clientaccesspolicy.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<access-policy>
+    <cross-domain-access>
+        <policy>
+            <allow-from http-request-headers="*">
+                <domain uri="*"/>
+            </allow-from>
+            <grant-to>
+                <resource path="/" include-subpaths="true"/>
+            </grant-to>
+        </policy>
+    </cross-domain-access>
+</access-policy>

--- a/docker/georoot/public/crossdomain.xml
+++ b/docker/georoot/public/crossdomain.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cross-domain-policy>
+    <allow-access-from domain="*"/>
+    <site-control permitted-cross-domain-policies="all"/>
+    <allow-http-request-headers-from domain="*" headers="*"/>
+</cross-domain-policy>


### PR DESCRIPTION
This addresses issues from some clients accessing GeoServer with older tooling like Silverlight.

This adds two configuration files for cross domain access. The text is copied from files of the same name on imai.dmz at E:\inetpub\wwwroot, with formatting applied to tidy indentation a bit.