### PR TITLE
Use earlier version of Maven instead of latest (MAP-8483)

### DIFF
--- a/docker/Dockerfile.wfs
+++ b/docker/Dockerfile.wfs
@@ -1,4 +1,4 @@
-FROM maven:latest AS BUILD
+FROM maven:3.9.9 AS BUILD
 
 WORKDIR /app
 COPY . .

--- a/docker/Dockerfile.wms
+++ b/docker/Dockerfile.wms
@@ -1,4 +1,4 @@
-FROM maven:latest AS BUILD
+FROM maven:3.9.9 AS BUILD
 
 WORKDIR /app
 COPY . .

--- a/docker/wms/Dockerfile
+++ b/docker/wms/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:latest AS BUILD
+FROM maven:3.9.9 AS BUILD
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
At present the WFS image fails to build with an error seen while running Maven tests. This change updates the version of the Maven image we use in WFS and WMS Dockerfiles from "latest" to "3.9.9", which would have been the latest version when WFS and WMS images were last built in September 2024.

I've confirmed we can build WFS and WMS images with this change: pushing this commit to branch https://github.com/bcgov/map-geoserver-cloud/tree/images/michaeltest-mar-25 triggered a successful build - https://github.com/bcgov/map-geoserver-cloud/actions/runs/23548494969 - and we can now see images with today's date of March 25 in Artifactory.